### PR TITLE
Fragment CSS and Refactored CSS Styling

### DIFF
--- a/Happy-Hour/src/main/java/com/happyhour/HappyHour/controllers/HappyHourController.java
+++ b/Happy-Hour/src/main/java/com/happyhour/HappyHour/controllers/HappyHourController.java
@@ -27,6 +27,7 @@ public class HappyHourController {
 
     @PostMapping("results")
     public String searchHH(Model model, @RequestParam String searchTerm){
+        model.addAttribute("title", "Search Results");
         ArrayList<HappyHour> searchResults = HourData.searchHappyHour(searchTerm, happyHourRepository.findAll());
         ArrayList<String> resultAddresses = new ArrayList<>();
 

--- a/Happy-Hour/src/main/java/com/happyhour/HappyHour/controllers/HomeController.java
+++ b/Happy-Hour/src/main/java/com/happyhour/HappyHour/controllers/HomeController.java
@@ -20,7 +20,7 @@ public class HomeController {
 
     @RequestMapping("index")
     public String index(Model model) {
-        model.addAttribute("title", "Test Page");
+        model.addAttribute("title", "Home");
         model.addAttribute("happyHours", happyHourRepository.findAll());
         return "index";
     }

--- a/Happy-Hour/src/main/java/com/happyhour/HappyHour/controllers/HomeController.java
+++ b/Happy-Hour/src/main/java/com/happyhour/HappyHour/controllers/HomeController.java
@@ -27,6 +27,7 @@ public class HomeController {
 
     @GetMapping("user-view/{hhId}")
     public String displayHH(Model model, @PathVariable int hhId){
+        model.addAttribute("title", "User View");
         Optional optHH = happyHourRepository.findById(hhId);
         if (optHH.isPresent()) {
             HappyHour hh = (HappyHour) optHH.get();

--- a/Happy-Hour/src/main/resources/static/css/happyhour.css
+++ b/Happy-Hour/src/main/resources/static/css/happyhour.css
@@ -14,6 +14,11 @@ body,html{
     height: 100%;
 }
 
+body {
+    font-family: Comic Sans MS, Comic Sans, cursive;
+    font-weight: bold; color: white;
+}
+
 .searchbar{
     margin-bottom: auto;
     margin-top: auto;

--- a/Happy-Hour/src/main/resources/static/css/happyhour.css
+++ b/Happy-Hour/src/main/resources/static/css/happyhour.css
@@ -14,7 +14,7 @@ body,html{
     height: 100%;
 }
 
-body {
+.body_text {
     font-family: Comic Sans MS, Comic Sans, cursive;
     font-weight: bold; color: white;
 }

--- a/Happy-Hour/src/main/resources/templates/fragments.html
+++ b/Happy-Hour/src/main/resources/templates/fragments.html
@@ -12,8 +12,6 @@
     <script type="text/javascript" th:src="@{/js/bootstrap.js}"></script>
 </head>
 
-<body th:fragment="body" class="container bg" style="font-family: Comic Sans MS, Comic Sans, cursive; font-weight: bold; color: white;"></body>
-
 <div th:fragment="header" class="page-header text-center my-5">
     <h1>Happy Hour Locator</h1>
 </div>

--- a/Happy-Hour/src/main/resources/templates/fragments.html
+++ b/Happy-Hour/src/main/resources/templates/fragments.html
@@ -12,6 +12,16 @@
     <script type="text/javascript" th:src="@{/js/bootstrap.js}"></script>
 </head>
 
+<div th:fragment="header" class="page-header text-center my-5">
+    <h1>Happy Hour Locator</h1>
+</div>
+
+<div th:fragment="navbar" class="navbar-header d-flex justify-content-flex-start text-center mb-4">
+    <a th:href="@{/index}" class="navbar-brand m-0 px-1 border">Home</a>
+    <p th:text="${title}" class="navbar-brand m-0 w-100 border"></p>
+</div>
+
+
 <div th:fragment="map">
     <!--The div element for the map -->
     <div id="map" style="width:1000px; height: 500px; margin: auto auto 100px;"><!--MAP GOES HERE--></div>

--- a/Happy-Hour/src/main/resources/templates/fragments.html
+++ b/Happy-Hour/src/main/resources/templates/fragments.html
@@ -16,7 +16,7 @@
     <h1>Happy Hour Locator</h1>
 </div>
 
-<div th:fragment="navbar" class="navbar-header d-flex justify-content-flex-start text-center mb-4">
+<div th:fragment="navbar" class="navbar-header d-flex justify-content-flex-start text-center mb-4 w-100">
     <a th:href="@{/index}" class="navbar-brand m-0 px-1 border">Home</a>
     <p th:text="${title}" class="navbar-brand m-0 w-100 border"></p>
 </div>

--- a/Happy-Hour/src/main/resources/templates/fragments.html
+++ b/Happy-Hour/src/main/resources/templates/fragments.html
@@ -70,7 +70,7 @@
 
 </script>
     <script th:inline="javascript" async="async" defer="defer"
-            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCC9CJzXEzUvpuomQqTVFL19juX8IaJVWw&callback=initMap">
+            src=REDACTED>
     </script>  <!--This script verifies Google API Key, establishes link with registered API products, and initialize Map Script-->
 </div>
 

--- a/Happy-Hour/src/main/resources/templates/fragments.html
+++ b/Happy-Hour/src/main/resources/templates/fragments.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" th:src="@{/js/bootstrap.js}"></script>
 </head>
 
+<body th:fragment="body" class="container bg" style="font-family: Comic Sans MS, Comic Sans, cursive; font-weight: bold; color: white;"></body>
+
 <div th:fragment="header" class="page-header text-center my-5">
     <h1>Happy Hour Locator</h1>
 </div>

--- a/Happy-Hour/src/main/resources/templates/fragments.html
+++ b/Happy-Hour/src/main/resources/templates/fragments.html
@@ -70,7 +70,7 @@
 
 </script>
     <script th:inline="javascript" async="async" defer="defer"
-            src=REDACTED>
+            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCC9CJzXEzUvpuomQqTVFL19juX8IaJVWw&callback=initMap">
     </script>  <!--This script verifies Google API Key, establishes link with registered API products, and initialize Map Script-->
 </div>
 

--- a/Happy-Hour/src/main/resources/templates/index.html
+++ b/Happy-Hour/src/main/resources/templates/index.html
@@ -12,7 +12,7 @@
         <div class="d-flex justify-content-center" style="height:45%">
             <form th:action="@{results}" method="post" class="d-flex flex-column">
                 <div class="searchbar">
-                    <input class="search_input" type="text" name="searchTerm" placeholder="Hello World">
+                    <input class="search_input" type="text" name="searchTerm" placeholder="Search Happy Hours Near You">
                     <button class="search_icon" type="submit"><i class="glyphicon glyphicon-search"></i></button>
                 </div>
             </form>

--- a/Happy-Hour/src/main/resources/templates/owner-home.html
+++ b/Happy-Hour/src/main/resources/templates/owner-home.html
@@ -4,7 +4,7 @@
 
 <title th:text="${title}"></title>
 
-<body class="container bg" style="font-family: Comic Sans MS, Comic Sans, cursive; font-weight: bold; color: white;">
+<body class="container bg body_text">
 
 <div th:replace="fragments :: header"></div>
 

--- a/Happy-Hour/src/main/resources/templates/owner-home.html
+++ b/Happy-Hour/src/main/resources/templates/owner-home.html
@@ -4,80 +4,80 @@
 
 <title th:text="${title}"></title>
 
-<body class="container bg body_text">
+<body class="container body_text">
+    <div class="bg">
+        <div th:replace="fragments :: header"></div>
 
-<div th:replace="fragments :: header"></div>
+        <div th:replace="fragments :: navbar"></div>
 
-<div th:replace="fragments :: navbar"></div>
-
-<div class="d-flex justify-content-end p-2" >
-    <a th:href="@{'/logout'}" class="btn btn-secondary btn-lg active" role="button" aria-pressed="true">Logout</a>
-</div>
-<div class="container">
-    <div class="row">
-        <div class="col-xs-6">
-<form method="post">
-    <label>CREATE NEW HAPPY HOUR</label>
-    <div class="form-group">
-        <label>Happy Hour Name
-            <input th:field="${happyHour.name}" class="form-control">
-        </label>
-        <p class="error" th:errors="${happyHour.name}"></p>
-    </div>
-    <div class="form-group">
-        <label>Happy Hour Day of Week
-            <input th:field="${happyHour.dayOfWeek}" class="form-control">
-        </label>
-        <p class="error" th:errors="${happyHour.dayOfWeek}"></p>
-    </div>
-    <div class="form-group">
-        <label>Happy Hour Address
-            <input th:field="${happyHour.address}" class="form-control">
-        </label>
-        <p class="error" th:errors="${happyHour.address}"></p>
-    </div>
-    <div class="form-group">
-        <label>Happy Hour Start Time
-            <input th:field="${happyHour.startTime}" class="form-control">
-        </label>
-        <p class="error" th:errors="${happyHour.startTime}"></p>
-    </div>
-    <div class="form-group">
-        <label>Happy Hour End Time
-            <input th:field="${happyHour.endTime}" class="form-control">
-        </label>
-        <p class="error" th:errors="${happyHour.endTime}"></p>
-    </div>
-    <div class="col text-center">
-        <input type="submit" value="Create" class="btn btn-primary">
-    </div>
-</form>
+        <div class="d-flex justify-content-end p-2" >
+            <a th:href="@{'/logout'}" class="btn btn-secondary btn-lg active" role="button" aria-pressed="true">Logout</a>
         </div>
-        <div class="col-xs-12">
-            <table class="table">
-                <thead>
-                <tr>
-                    <th scope="col">Business</th>
-                    <th scope="col">Days of Week</th>
-                    <th scope="col">Start Time</th>
-                    <th scope="col">End Time</th>
-                    <th scope="col">Address</th>
-                </tr>
-                </thead>
-                <tbody>
-                    <tr th:each="happyHour : ${happyHours}">
-                        <td th:text="${happyHour.name}"></td>
-                        <td th:text="${happyHour.dayOfWeek}"></td>
-                        <td th:text="${happyHour.startTime}"></td>
-                        <td th:text="${happyHour.endTime}"></td>
-                        <td th:text="${happyHour.address}"></td>
-                    </tr>
-                </tbody>
-            </table>
+        <div class="container">
+            <div class="row">
+                <div class="col-xs-6">
+        <form method="post">
+            <label>CREATE NEW HAPPY HOUR</label>
+            <div class="form-group">
+                <label>Happy Hour Name
+                    <input th:field="${happyHour.name}" class="form-control">
+                </label>
+                <p class="error" th:errors="${happyHour.name}"></p>
+            </div>
+            <div class="form-group">
+                <label>Happy Hour Day of Week
+                    <input th:field="${happyHour.dayOfWeek}" class="form-control">
+                </label>
+                <p class="error" th:errors="${happyHour.dayOfWeek}"></p>
+            </div>
+            <div class="form-group">
+                <label>Happy Hour Address
+                    <input th:field="${happyHour.address}" class="form-control">
+                </label>
+                <p class="error" th:errors="${happyHour.address}"></p>
+            </div>
+            <div class="form-group">
+                <label>Happy Hour Start Time
+                    <input th:field="${happyHour.startTime}" class="form-control">
+                </label>
+                <p class="error" th:errors="${happyHour.startTime}"></p>
+            </div>
+            <div class="form-group">
+                <label>Happy Hour End Time
+                    <input th:field="${happyHour.endTime}" class="form-control">
+                </label>
+                <p class="error" th:errors="${happyHour.endTime}"></p>
+            </div>
+            <div class="col text-center">
+                <input type="submit" value="Create" class="btn btn-primary">
+            </div>
+        </form>
+                </div>
+                <div class="col-xs-12">
+                    <table class="table">
+                        <thead>
+                        <tr>
+                            <th scope="col">Business</th>
+                            <th scope="col">Days of Week</th>
+                            <th scope="col">Start Time</th>
+                            <th scope="col">End Time</th>
+                            <th scope="col">Address</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr th:each="happyHour : ${happyHours}">
+                                <td th:text="${happyHour.name}"></td>
+                                <td th:text="${happyHour.dayOfWeek}"></td>
+                                <td th:text="${happyHour.startTime}"></td>
+                                <td th:text="${happyHour.endTime}"></td>
+                                <td th:text="${happyHour.address}"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
-</div>
-
 
 </body>
 </html>

--- a/Happy-Hour/src/main/resources/templates/owner-home.html
+++ b/Happy-Hour/src/main/resources/templates/owner-home.html
@@ -6,14 +6,10 @@
 
 <body class="container bg" style="font-family: Comic Sans MS, Comic Sans, cursive; font-weight: bold; color: white;">
 
-<div class="page-header text-center my-5">    <!--This header should be fragmented-->
-    <h1>Happy Hour Locator</h1>
-</div>
+<div th:replace="fragments :: header"></div>
 
-<div class="navbar-header d-flex justify-content-flex-start text-center mb-4">  <!--This nav bar should be fragmented-->
-    <a th:href="@{/index}" class="navbar-brand m-0 px-1 border">Home</a>
-    <p th:text="${title}" class="navbar-brand m-0 w-100 border"></p>
-</div>
+<div th:replace="fragments :: navbar"></div>
+
 <div class="d-flex justify-content-end p-2" >
     <a th:href="@{'/logout'}" class="btn btn-secondary btn-lg active" role="button" aria-pressed="true">Logout</a>
 </div>

--- a/Happy-Hour/src/main/resources/templates/owner-login.html
+++ b/Happy-Hour/src/main/resources/templates/owner-login.html
@@ -7,14 +7,9 @@
 <!--Discuss if we should or want to add this font styling to happyhour.css-->
 <body class="container bg" style="font-family: Comic Sans MS, Comic Sans, cursive; font-weight: bold; color: white;">
 
-    <div class="page-header text-center my-5">    <!--This header should be fragmented-->
-        <h1>Happy Hour Locator</h1>
-    </div>
+    <div th:replace="fragments :: header"></div>
 
-    <div class="navbar-header d-flex justify-content-flex-start text-center mb-4">  <!--This nav bar should be fragmented-->
-            <a th:href="@{/index}" class="navbar-brand m-0 px-1 border">Home</a>
-            <p th:text="${title}" class="navbar-brand m-0 w-100 border"></p>
-    </div>
+    <div th:replace="fragments :: navbar"></div>
 
     <div class="row d-flex justify-content-center">
         <form method="post">

--- a/Happy-Hour/src/main/resources/templates/owner-login.html
+++ b/Happy-Hour/src/main/resources/templates/owner-login.html
@@ -14,7 +14,7 @@
         <div class="row d-flex justify-content-center">
             <form method="post">
                 <div class="form-group">
-                    <label>Username</label>
+                    <label>Username
                         <input class="form-control" th:field="${loginFormDTO.username}">
                     </label>
                     <p class="error" th:errors="${loginFormDTO.username}"></p>

--- a/Happy-Hour/src/main/resources/templates/owner-login.html
+++ b/Happy-Hour/src/main/resources/templates/owner-login.html
@@ -4,30 +4,32 @@
 
 <title th:text="${title}"></title>
 
-<body class="container bg body_text">
+<body class="container body_text">
+    <div class="bg">
 
-    <div th:replace="fragments :: header"></div>
+        <div th:replace="fragments :: header"></div>
 
-    <div th:replace="fragments :: navbar"></div>
+        <div th:replace="fragments :: navbar"></div>
 
-    <div class="row d-flex justify-content-center">
-        <form method="post">
-            <div class="form-group">
-                <label>Username</label>
-                    <input class="form-control" th:field="${loginFormDTO.username}">
-                </label>
-                <p class="error" th:errors="${loginFormDTO.username}"></p>
-            </div>
-            <div class="form-group">
-                <label>Password
-                    <input class="form-control" th:field="${loginFormDTO.password}" type="password">
-                </label>
-                <p class="error" th:errors="${loginFormDTO.password}"></p>
-            </div>
+        <div class="row d-flex justify-content-center">
+            <form method="post">
+                <div class="form-group">
+                    <label>Username</label>
+                        <input class="form-control" th:field="${loginFormDTO.username}">
+                    </label>
+                    <p class="error" th:errors="${loginFormDTO.username}"></p>
+                </div>
+                <div class="form-group">
+                    <label>Password
+                        <input class="form-control" th:field="${loginFormDTO.password}" type="password">
+                    </label>
+                    <p class="error" th:errors="${loginFormDTO.password}"></p>
+                </div>
 
-            <input type="submit" class="btn btn-primary" value="Log In" />
-        </form>
+                <input type="submit" class="btn btn-primary" value="Log In" />
+            </form>
+        </div>
+        <p class="row d-flex justify-content-center my-2">Don't have an account?<a href="/owner-registration">Register for one.</a></p>
     </div>
-    <p class="row d-flex justify-content-center my-2">Don't have an account?<a href="/owner-registration">Register for one.</a></p>
 </body>
 </html>

--- a/Happy-Hour/src/main/resources/templates/owner-login.html
+++ b/Happy-Hour/src/main/resources/templates/owner-login.html
@@ -4,8 +4,7 @@
 
 <title th:text="${title}"></title>
 
-<!--Discuss if we should or want to add this font styling to happyhour.css-->
-<body class="container bg" style="font-family: Comic Sans MS, Comic Sans, cursive; font-weight: bold; color: white;">
+<body class="container bg body_text">
 
     <div th:replace="fragments :: header"></div>
 

--- a/Happy-Hour/src/main/resources/templates/owner-registration.html
+++ b/Happy-Hour/src/main/resources/templates/owner-registration.html
@@ -10,33 +10,30 @@
 
         <div th:replace="fragments :: navbar"></div>
 
-        <div class="container h-100">
-            <div class="d-flex justify-content-center">
-                <div class="row h-100 justify-content-center align-items-center">
-                    <form method="post">
-                        <div class="form-group">
-                            <label>Username
-                                <input class="form-control" th:field="${registerFormDTO.username}"/>
-                            </label>
-                            <p class="error" th:errors="${registerFormDTO.username}"></p>
-                        </div>
-                        <div class="form-group">
-                            <label>Password
-                                <input class="form-control" th:field="${registerFormDTO.password}" type="password"/>
-                            </label>
-                            <p class="error" th:errors="${registerFormDTO.password}"></p>
-                        </div>
-                        <div class="form-group">
-                            <label>Verify Password
-                                <input class="form-control" th:field="${registerFormDTO.verifyPassword}" type="password"/>
-                            </label>
-                        </div>
-
-                        <input type="Submit" class="btn btn-primary" value="Register"/>
-                    </form>
+        <div class="row d-flex justify-content-center">
+            <form method="post">
+                <div class="form-group">
+                    <label>Username
+                        <input class="form-control" th:field="${registerFormDTO.username}"/>
+                    </label>
+                    <p class="error" th:errors="${registerFormDTO.username}"></p>
                 </div>
-            </div>
+                <div class="form-group">
+                    <label>Password
+                        <input class="form-control" th:field="${registerFormDTO.password}" type="password"/>
+                    </label>
+                    <p class="error" th:errors="${registerFormDTO.password}"></p>
+                </div>
+                <div class="form-group">
+                    <label>Verify Password
+                        <input class="form-control" th:field="${registerFormDTO.verifyPassword}" type="password"/>
+                    </label>
+                </div>
+
+                <input type="Submit" class="btn btn-primary" value="Register"/>
+            </form>
         </div>
+
     </div>
 </body>
 

--- a/Happy-Hour/src/main/resources/templates/owner-registration.html
+++ b/Happy-Hour/src/main/resources/templates/owner-registration.html
@@ -6,13 +6,9 @@
 
 <body class="container bg" style="font-family: Comic Sans MS, Comic Sans, cursive; font-weight: bold; color: white;">
 
-    <div class="page-header text-center my-5">    <!--This header should be fragmented-->
-        <h1>Happy Hour Locator</h1>
-    </div>
-    <div class="navbar-header d-flex justify-content-flex-start text-center mb-4">  <!--This nav bar should be fragmented-->
-        <a th:href="@{/index}" class="navbar-brand m-0 px-1 border">Home</a>
-        <p th:text="${title}" class="navbar-brand m-0 w-100 border"></p>
-    </div>
+    <div th:replace="fragments :: header"></div>
+
+    <div th:replace="fragments :: navbar"></div>
 
     <div class="container h-100">
         <div class="d-flex justify-content-center">

--- a/Happy-Hour/src/main/resources/templates/owner-registration.html
+++ b/Happy-Hour/src/main/resources/templates/owner-registration.html
@@ -4,7 +4,7 @@
 </head>
 <title th:text="${title}"></title>
 
-<body class="container bg" style="font-family: Comic Sans MS, Comic Sans, cursive; font-weight: bold; color: white;">
+<body class="container bg body_text">
 
     <div th:replace="fragments :: header"></div>
 

--- a/Happy-Hour/src/main/resources/templates/owner-registration.html
+++ b/Happy-Hour/src/main/resources/templates/owner-registration.html
@@ -4,40 +4,40 @@
 </head>
 <title th:text="${title}"></title>
 
-<body class="container bg body_text">
+<body class="container body_text">
+    <div class="bg">
+        <div th:replace="fragments :: header"></div>
 
-    <div th:replace="fragments :: header"></div>
+        <div th:replace="fragments :: navbar"></div>
 
-    <div th:replace="fragments :: navbar"></div>
+        <div class="container h-100">
+            <div class="d-flex justify-content-center">
+                <div class="row h-100 justify-content-center align-items-center">
+                    <form method="post">
+                        <div class="form-group">
+                            <label>Username
+                                <input class="form-control" th:field="${registerFormDTO.username}"/>
+                            </label>
+                            <p class="error" th:errors="${registerFormDTO.username}"></p>
+                        </div>
+                        <div class="form-group">
+                            <label>Password
+                                <input class="form-control" th:field="${registerFormDTO.password}" type="password"/>
+                            </label>
+                            <p class="error" th:errors="${registerFormDTO.password}"></p>
+                        </div>
+                        <div class="form-group">
+                            <label>Verify Password
+                                <input class="form-control" th:field="${registerFormDTO.verifyPassword}" type="password"/>
+                            </label>
+                        </div>
 
-    <div class="container h-100">
-        <div class="d-flex justify-content-center">
-            <div class="row h-100 justify-content-center align-items-center">
-                <form method="post">
-                    <div class="form-group">
-                        <label>Username
-                            <input class="form-control" th:field="${registerFormDTO.username}"/>
-                        </label>
-                        <p class="error" th:errors="${registerFormDTO.username}"></p>
-                    </div>
-                    <div class="form-group">
-                        <label>Password
-                            <input class="form-control" th:field="${registerFormDTO.password}" type="password"/>
-                        </label>
-                        <p class="error" th:errors="${registerFormDTO.password}"></p>
-                    </div>
-                    <div class="form-group">
-                        <label>Verify Password
-                            <input class="form-control" th:field="${registerFormDTO.verifyPassword}" type="password"/>
-                        </label>
-                    </div>
-
-                    <input type="Submit" class="btn btn-primary" value="Register"/>
-                </form>
+                        <input type="Submit" class="btn btn-primary" value="Register"/>
+                    </form>
+                </div>
             </div>
         </div>
     </div>
-<!--</div> -->
 </body>
 
 </html>

--- a/Happy-Hour/src/main/resources/templates/results.html
+++ b/Happy-Hour/src/main/resources/templates/results.html
@@ -15,11 +15,6 @@
 
         <div class="h-auto pb-5">
             <table class="table">
-                <thead>
-                <tr>
-                    <th>Happy Hours</th>
-                </tr>
-                </thead>
                 <tr>
                     <th> Name </th>
                     <th> Address </th>

--- a/Happy-Hour/src/main/resources/templates/results.html
+++ b/Happy-Hour/src/main/resources/templates/results.html
@@ -13,7 +13,7 @@
             <h2 th:text="'Happy Hours with '+${searchTerm}"></h2>
         </div>
 
-        <div class="h-auto mt-5">
+        <div class="h-auto pb-5">
             <table class="table">
                 <thead>
                 <tr>

--- a/Happy-Hour/src/main/resources/templates/results.html
+++ b/Happy-Hour/src/main/resources/templates/results.html
@@ -9,29 +9,33 @@
 
         <div th:replace="fragments :: navbar"></div>
 
-        <h2 class = "centered">Happy Hours with </h2>
-        <h2 class="centered" th:text="${searchTerm}"></h2>
-        <table class="table">
-            <thead>
-            <tr>
-                <th>Happy Hours</th>
-            </tr>
-            </thead>
-            <tr>
-                <th> Name </th>
-                <th> Address </th>
-                <th> Times </th>
-            </tr>
-            <tbody>
-            <th:block th:each="happy : ${happyHours}">
+        <div class="d-flex w-100">
+            <h2 th:text="'Happy Hours with '+${searchTerm}"></h2>
+        </div>
+
+        <div>
+            <table class="table">
+                <thead>
                 <tr>
-                    <td th:text="${happy.name}" ></td>
-                    <td th:text="${happy.address}" ></td>
-                    <td th:text="${happy.startTime}+' - '+${happy.endTime}" ></td>
+                    <th>Happy Hours</th>
                 </tr>
-            </th:block>
-            </tbody>
-        </table>
+                </thead>
+                <tr>
+                    <th> Name </th>
+                    <th> Address </th>
+                    <th> Times </th>
+                </tr>
+                <tbody>
+                <th:block th:each="happy : ${happyHours}">
+                    <tr>
+                        <td th:text="${happy.name}" ></td>
+                        <td th:text="${happy.address}" ></td>
+                        <td th:text="${happy.startTime}+' - '+${happy.endTime}" ></td>
+                    </tr>
+                </th:block>
+                </tbody>
+            </table>
+        </div>
 
         <div th:replace="fragments :: map"></div>
     </div>

--- a/Happy-Hour/src/main/resources/templates/results.html
+++ b/Happy-Hour/src/main/resources/templates/results.html
@@ -8,13 +8,10 @@
     <div class="container h-100">
         <div class="d-flex justify-content-center h-100">
             <div class="container body-content">
-                <div class="page-header text-center my-5">
-                    <h1>Happy Hour Locator</h1>
-                </div>
-                <div class="navbar-header d-flex justify-content-flex-start text-center mb-4">
-                    <a th:href="@{/index}" class="navbar-brand m-0 px-1 border">Home</a>
-                    <p th:text="${title}" class="navbar-brand m-0 w-100 border"></p>
-                </div>
+                <div th:replace="fragments :: header"></div>
+
+                <div th:replace="fragments :: navbar"></div>
+
                 <h2 class = "centered">Happy Hours with </h2>
                 <h2 class="centered" th:text="${searchTerm}"></h2>
                 <table class="table">

--- a/Happy-Hour/src/main/resources/templates/results.html
+++ b/Happy-Hour/src/main/resources/templates/results.html
@@ -3,43 +3,36 @@
 <head th:replace="fragments :: head">
 </head>
 <title th:text="${title}"></title>
-<body >
-<div class="bg">
-    <div class="container h-100">
-        <div class="d-flex justify-content-center h-100">
-            <div class="container body-content">
-                <div th:replace="fragments :: header"></div>
+<body class="container bg body_text">
 
-                <div th:replace="fragments :: navbar"></div>
+    <div th:replace="fragments :: header"></div>
 
-                <h2 class = "centered">Happy Hours with </h2>
-                <h2 class="centered" th:text="${searchTerm}"></h2>
-                <table class="table">
-                    <thead>
-                    <tr>
-                        <th>Happy Hours</th>
-                    </tr>
-                    </thead>
-                    <tr>
-                        <th> Name </th>
-                        <th> Address </th>
-                        <th> Times </th>
-                    </tr>
-                    <tbody>
-                    <th:block th:each="happy : ${happyHours}">
-                        <tr>
-                            <td th:text="${happy.name}" ></td>
-                            <td th:text="${happy.address}" ></td>
-                            <td th:text="${happy.startTime}+' - '+${happy.endTime}" ></td>
-                        </tr>
-                    </th:block>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-</div>
+    <div th:replace="fragments :: navbar"></div>
 
-<div th:replace="fragments :: map"></div>
+    <h2 class = "centered">Happy Hours with </h2>
+    <h2 class="centered" th:text="${searchTerm}"></h2>
+    <table class="table">
+        <thead>
+        <tr>
+            <th>Happy Hours</th>
+        </tr>
+        </thead>
+        <tr>
+            <th> Name </th>
+            <th> Address </th>
+            <th> Times </th>
+        </tr>
+        <tbody>
+        <th:block th:each="happy : ${happyHours}">
+            <tr>
+                <td th:text="${happy.name}" ></td>
+                <td th:text="${happy.address}" ></td>
+                <td th:text="${happy.startTime}+' - '+${happy.endTime}" ></td>
+            </tr>
+        </th:block>
+        </tbody>
+    </table>
+
+    <div th:replace="fragments :: map"></div>
 </body>
 </html>

--- a/Happy-Hour/src/main/resources/templates/results.html
+++ b/Happy-Hour/src/main/resources/templates/results.html
@@ -3,36 +3,37 @@
 <head th:replace="fragments :: head">
 </head>
 <title th:text="${title}"></title>
-<body class="container bg body_text">
+<body class="container body_text">
+    <div class="bg">
+        <div th:replace="fragments :: header"></div>
 
-    <div th:replace="fragments :: header"></div>
+        <div th:replace="fragments :: navbar"></div>
 
-    <div th:replace="fragments :: navbar"></div>
-
-    <h2 class = "centered">Happy Hours with </h2>
-    <h2 class="centered" th:text="${searchTerm}"></h2>
-    <table class="table">
-        <thead>
-        <tr>
-            <th>Happy Hours</th>
-        </tr>
-        </thead>
-        <tr>
-            <th> Name </th>
-            <th> Address </th>
-            <th> Times </th>
-        </tr>
-        <tbody>
-        <th:block th:each="happy : ${happyHours}">
+        <h2 class = "centered">Happy Hours with </h2>
+        <h2 class="centered" th:text="${searchTerm}"></h2>
+        <table class="table">
+            <thead>
             <tr>
-                <td th:text="${happy.name}" ></td>
-                <td th:text="${happy.address}" ></td>
-                <td th:text="${happy.startTime}+' - '+${happy.endTime}" ></td>
+                <th>Happy Hours</th>
             </tr>
-        </th:block>
-        </tbody>
-    </table>
+            </thead>
+            <tr>
+                <th> Name </th>
+                <th> Address </th>
+                <th> Times </th>
+            </tr>
+            <tbody>
+            <th:block th:each="happy : ${happyHours}">
+                <tr>
+                    <td th:text="${happy.name}" ></td>
+                    <td th:text="${happy.address}" ></td>
+                    <td th:text="${happy.startTime}+' - '+${happy.endTime}" ></td>
+                </tr>
+            </th:block>
+            </tbody>
+        </table>
 
-    <div th:replace="fragments :: map"></div>
+        <div th:replace="fragments :: map"></div>
+    </div>
 </body>
 </html>

--- a/Happy-Hour/src/main/resources/templates/results.html
+++ b/Happy-Hour/src/main/resources/templates/results.html
@@ -13,7 +13,7 @@
             <h2 th:text="'Happy Hours with '+${searchTerm}"></h2>
         </div>
 
-        <div>
+        <div class="h-auto mt-5">
             <table class="table">
                 <thead>
                 <tr>

--- a/Happy-Hour/src/main/resources/templates/user-view.html
+++ b/Happy-Hour/src/main/resources/templates/user-view.html
@@ -5,8 +5,8 @@
 <title th:text="${title}"></title>
 <body >
 <div class="bg">
-    <div class="container h-100">
-        <div class="d-flex justify-content-center h-100">
+    <div class="container">
+        <div class="d-flex justify-content-center h-auto pb-5">
             <table class="table">
                 <thead>
                 <tr>
@@ -23,10 +23,14 @@
                 </tbody>
 
             </table>
+
         </div>
+
+        <div th:replace="fragments :: map"></div>
+
     </div>
 </div>
-<div th:replace="fragments :: map"></div>
+
 </body>
 
 </html>


### PR DESCRIPTION
- Fragmented navbar/header. Replaced navbar/header with fragmented code on the following:
>- owner-login
>- owner-registration
>- owner-home
>- results
- Refactored results.html for improved CSS styling.  Also got rid of the dead space before the map, and made the table height auto adjust.
- Got rid of the dead space before the map, and made the table height auto adjust on user-view.
- Add new default search text to instruct the user what they can do at index.html.
- Got rid of table header on results.html for redudancy.
- Fixed pages with default page headers (index shows "Test-Page" on tab).