### PR TITLE
Refactored toString method to display "happyHourName: dayOfWeek start…

### DIFF
--- a/Happy-Hour/src/main/java/com/happyhour/HappyHour/models/HappyHour.java
+++ b/Happy-Hour/src/main/java/com/happyhour/HappyHour/models/HappyHour.java
@@ -75,12 +75,10 @@ public class HappyHour extends AbstractEntity {
 
     @Override
     public String toString() {
-        return "{"   + name +
-                ", " + dayOfWeek +
-                ", " + address +
-                ", " + startTime +
-                ", " + endTime +
-                '}';
+        return         name +
+                ": " + dayOfWeek +
+                " " + startTime +
+                " - " + endTime;
     }
 
 }


### PR DESCRIPTION
Refactored HappyHour toString method to display the following format:

"happyHourName: dayOfWeek startTime - endTime"

Example of what is seen under "New Happy Hours" on Index:
1$ Guinness: Friday 1 - 5    

The above is still a clickable link to see more information about the happy hour (userview) which includes address/map if they want to know more.  **This code may need to be refactored again to display dayOfWeek/Time correctly once Dai finishes formatting those two variables in Happy Hour Class**

Code:
@Override
    public String toString() {
        return         name +
                ": " + dayOfWeek +
                " " + startTime +
                " - " + endTime;
    }